### PR TITLE
Update Org json files to setting format

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds (npsp) - Beta Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds (npsp) - Dev Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds (npsp) - Feature Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds (npsp) - Release Test Org",
   "edition": "Enterprise",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Outbound Funds %28npsp%29</fullName>
-    <apiAccessLevel>Unrestricted</apiAccessLevel>
-    <description>Extension package to connect Outbound Funds to the NPSP.</description>
-    <namespacePrefix>outfundsnpspext</namespacePrefix>
     <types>
         <members>GAU_Expenditure__c.GAU_Expenditure_Compact_Layout</members>
         <name>CompactLayout</name>


### PR DESCRIPTION
**Critical Changes**
Based on Salesforce Winer 19, you can specify scratch org settings or org preferences in your scratch org definition file, but not both. Salesforce encourages to convert org preferences to scratch org settings in your scratch org definition. Scratch org settings provide more settings that aren’t currently available as org preferences.

**Issues Closed**
#8 